### PR TITLE
Fix dropdown load failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,9 @@
 
       } catch (err) {
         console.error("Failed to load dropdown data:", err);
+        addRow();
+        document.getElementById("add-row-btn").disabled = false;
+        document.getElementById("sync-status").textContent = "⚠️ Using empty dropdowns";
       }
     });
 


### PR DESCRIPTION
## Summary
- handle failing dropdown data fetch by adding a row and enabling controls

## Testing
- `git log -1 -p`

------
https://chatgpt.com/codex/tasks/task_e_682ab94030a08321a7508a0dfd790b7d